### PR TITLE
adds to current time zone

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
     <% if user_signed_in? %>
       <div class="d-flex justify-content-between align-items-center mb-4">
         <%= link_to 'Logout', destroy_user_session_path, data: { turbo_method: :delete }, id: "logout-link", class: 'btn btn-orange' %>
-        <p>Current Time Zone: <%= current_user.time_zone || "Not set" %></p>
+        <p>Current Time Zone: <%= current_user.time_zone || "Not automatically set" %></p>
       </div>
     <% end %>
     <%= render 'shared/flash_messages' %>


### PR DESCRIPTION
reverting to a previous commit here for cleaner code where the functionality works and chrome and safari on desktop work. Does not detect time zone on ios. Will need to have the user self select their time zone if not detected. 