### PR TITLE
import flash_controller.js console error debugging

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,7 +1,6 @@
 //= link_tree ../images
 //= link application.js
 //= link controllers/application.js
-//= link controllers/flash_controller.js
 //= link controllers/index.js
 //= link_directory ../stylesheets .css
 //= link_tree ../../javascript .js

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,6 +2,7 @@ import "@hotwired/turbo-rails";
 import "controllers";
 
 document.addEventListener("turbo:load", () => {
+  console.log("Turbo loaded, Stimulus controllers initialized.");
   try {
     const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,13 +1,7 @@
 // app/javascript/controllers/index.js
-// import { application } from "./application";
-// import FlashController from "./flash_controller";
-
-// application.register("flash", FlashController);
 
 import { Application } from "@hotwired/stimulus";
 import FlashController from "./flash_controller";
 
 const application = Application.start();
 application.register("flash", FlashController);
-
-console.log("Stimulus initialized"); // Debugging: Verify Stimulus is loaded

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,17 +4,18 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.script_src :self, :unsafe_inline, :unsafe_eval
+    policy.default_src :self, :https
+    policy.font_src    :self, :https, :data
+    policy.img_src     :self, :https, :data
+    policy.object_src  :none
+    policy.script_src  :self, :https
+    policy.style_src   :self, :https
+    # Specify URI for violation reports
+    # policy.report_uri "/csp-violation-report-endpoint"
+  end
 #
 #   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
 #   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
@@ -22,4 +23,4 @@
 #
 #   # Report violations without enforcing the policy.
 #   # config.content_security_policy_report_only = true
-# end
+end


### PR DESCRIPTION
Removes unnecessary asset links in manifest.js for flash_controller.js as it is imnported and managed by stimulus, adds console.log for turbo loaded and stimulus controllers initialized in application.js, precompiled assets, modify/verifuy csp settings in content_security_policy.rb. will test on iphone after new deploy