### PR TITLE
modify CSP file for javasript scripts

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -6,21 +6,20 @@
 
 Rails.application.configure do
   config.content_security_policy do |policy|
-    policy.script_src :self, :unsafe_inline, :unsafe_eval
     policy.default_src :self, :https
     policy.font_src    :self, :https, :data
     policy.img_src     :self, :https, :data
     policy.object_src  :none
-    policy.script_src  :self, :https
+    policy.script_src  :self, :https, :unsafe_inline, :unsafe_eval
     policy.style_src   :self, :https
     # Specify URI for violation reports
     # policy.report_uri "/csp-violation-report-endpoint"
   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
+
+  # Generate session nonces for permitted importmap, inline scripts, and inline styles.
+  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  config.content_security_policy_nonce_directives = %w(script-src style-src)
+
+  # Report violations without enforcing the policy.
+  # config.content_security_policy_report_only = true
 end


### PR DESCRIPTION
Modifies the CSP to consolidate all allowed sources into a single script_src directive. Was getting errors in inspect on iphone. 