### PR TITLE
previous challenge show page @total_time, dropdown, logout button, back to dashboard button.

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,39 +1,34 @@
-// Ensure dropdown menu styles do not conflict
-.dropdown-menu {
-  display: none; // Hidden by default
-  position: absolute;
-  z-index: 1000;
+// Container for sessions
+#sessions-container {
+  max-height: 400px; // Adjust as needed
+  overflow-y: auto; // Enable scrolling for large content
+  border: 1px solid #ccc; // Add border for better visibility
+  padding: 10px; // Add padding for spacing
+  display: none; // Default hidden
 }
 
-.dropdown.show .dropdown-menu {
-  display: block !important; // Ensure proper toggling
+// Bootstrap collapse classes
+.collapse {
+  display: none;
 }
 
-.previous-sessions-container {
-  max-height: 550px;
-  /* Restrict the height of the container */
-  overflow-y: auto;
-  /* Add vertical scrolling for overflowing content */
-  border: 1px solid #ccc;
-  /* Optional: Add a border for better visual separation */
-  padding: 10px;
-  /* Optional: Add padding for better spacing */
+.collapse.show {
+  display: block;
+}
 
-  ul.session-list {
-    overflow-y: auto;
-    /* Enable vertical scrolling for overflowing content */
-    max-height: 550px;
-    /* Limit the height of the ul */
-    margin: 0;
-    /* Remove default margin */
-    padding: 0;
-    /* Remove default padding */
-    list-style: none;
-    /* Remove bullet points */
+// Custom button styling
+.btn-orange {
+  background-color: #ff8c00; // Orange background
+  color: #000; // Black text
+  border: none; // Remove border
+
+  &:hover {
+    background-color: #e67e22; // Darker orange on hover
+    color: #000; // Ensure text remains black
   }
 }
 
-// Flash message styles
+// Flash messages
 .flash-container {
   position: fixed;
   top: 10px;
@@ -45,19 +40,34 @@
 
 .flash-message {
   transition: opacity 1s ease-in-out;
-  background-color: #f8d7da;
-  color: #721c24;
-  border: 1px solid #f5c6cb;
+  background-color: #f8d7da; // Light red background
+  color: #721c24; // Dark red text
+  border: 1px solid #f5c6cb; // Red border
   border-radius: 5px;
   padding: 10px 15px;
   margin-bottom: 10px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+
+  &.fade-out {
+    opacity: 0;
+  }
 }
 
-.flash-message.fade-out {
-  opacity: 0;
+// Timezone display
+#timezone-display {
+  position: absolute;
+  top: 10px;
+  right: 20px;
+  font-size: 14px;
+  color: #333; // Neutral text color
 }
 
+// Timezone selection form
+#timezone-selection {
+  margin-top: 20px;
+}
+
+// Responsive styles
 @media (max-width: 576px) {
   .flash-container {
     top: 20px;

--- a/app/controllers/challenges_controller.rb
+++ b/app/controllers/challenges_controller.rb
@@ -1,8 +1,9 @@
-class ChallengeController < ApplicationController
+class ChallengesController < ApplicationController
   before_action :authenticate_user!
 
   def show
     @challenge = current_user.challenges.find(params[:id])
     @outdoor_sessions = @challenge.outdoor_sessions.order(start_time: :desc)
+    @total_time = @challenge.total_time
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -25,19 +25,21 @@ document.addEventListener("turbo:load", () => {
       })
       .catch((error) => {
         console.error("Fetch API error:", error);
-        document.getElementById("timezone-selection").style.display = "block";
+        const timezoneSelection = document.getElementById("timezone-selection");
+        if (timezoneSelection) timezoneSelection.style.display = "block";
       });
   } catch (error) {
     console.error("Error in time zone detection:", error);
-    document.getElementById("timezone-selection").style.display = "block";
+    const timezoneSelection = document.getElementById("timezone-selection");
+    if (timezoneSelection) timezoneSelection.style.display = "block";
   }
 
   // Initialize Bootstrap Dropdowns
-  const dropdownElements = document.querySelectorAll('.dropdown-toggle');
+  const dropdownElements = document.querySelectorAll(".dropdown-toggle");
   dropdownElements.forEach((dropdown) => {
     console.log("Initializing dropdown:", dropdown);
-
-    // Use global Bootstrap instance to initialize
     new bootstrap.Dropdown(dropdown);
   });
+
+  console.log("Bootstrap initialized.");
 });

--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -4,4 +4,9 @@ class Challenge < ApplicationRecord
 
   validates :year, presence: true, numericality: { only_integer: true }, uniqueness: { scope: :user_id }
   validates :start_date, :end_date, presence: true
+
+  # Calculate total time from associated outdoor sessions
+  def total_time
+    outdoor_sessions.sum(:duration).round(2)
+  end
 end

--- a/app/views/challenges/show.html.erb
+++ b/app/views/challenges/show.html.erb
@@ -1,17 +1,27 @@
 <h1>Challenge for <%= @challenge.year %></h1>
-<p>Total Time: <%= @challenge.total_time %> hours</p>
+<p>Total Time: <%= @total_time %> hours</p>
 <p>Start Date: <%= @challenge.start_date %></p>
 <p>End Date: <%= @challenge.end_date %></p>
 
 <h2>Outdoor Sessions</h2>
-<ul>
-  <% @outdoor_sessions.each do |session| %>
-    <li>
-      <strong>Start:</strong> <%= session.start_time %>,
-      <strong>Duration:</strong> <%= session.duration %> hours,
-      <strong>Description:</strong> <%= session.description %>
-    </li>
-  <% end %>
-</ul>
+<button
+  class="btn btn-secondary mb-2"
+  type="button"
+  data-bs-toggle="collapse"
+  data-bs-target="#sessions-container"
+  aria-expanded="false"
+  aria-controls="sessions-container">
+  Expand Sessions
+</button>
 
-<%= link_to "Back to Dashboard", root_path, class: "btn btn-primary" %>
+<div id="sessions-container" class="collapse">
+  <ul>
+    <% @outdoor_sessions.each do |session| %>
+      <li>
+        <strong>Start:</strong> <%= session.start_time %>,
+        <strong>Duration:</strong> <%= session.duration %> hours,
+        <strong>Description:</strong> <%= session.description %>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
   <!-- Importmap for JavaScript -->
   <%= javascript_importmap_tags %>
 
-   <!-- Bootstrap CSS via CDN -->
+  <!-- Bootstrap CSS via CDN -->
   <link
     rel="stylesheet"
     href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
@@ -27,25 +27,32 @@
     <% if user_signed_in? %>
       <!-- Navbar Section -->
       <div class="d-flex justify-content-between align-items-center mb-4">
-        <%= link_to 'Logout', destroy_user_session_path, data: { turbo_method: :delete }, id: "logout-link", class: 'btn btn-orange' %>
+        <div>
+          <%= link_to 'Logout', destroy_user_session_path, data: { turbo_method: :delete }, id: "logout-link", class: 'btn btn-warning mb-2' %>
 
-        <% if current_user.time_zone.present? %>
-          <p id="timezone-display">Current Time Zone: <%= current_user.time_zone %></p>
-        <% else %>
-          <!-- Time Zone Selection Form -->
-          <div id="timezone-selection">
-            <p>We couldn't detect your time zone. Please select it manually:</p>
-            <%= form_with(url: "/set_time_zone", method: :post, local: true) do |form| %>
-              <div class="form-group">
-                <%= form.label :time_zone, "Select Your Time Zone" %>
-                <%= form.time_zone_select :time_zone, ActiveSupport::TimeZone.all, {}, class: "form-control" %>
-              </div>
-              <div class="form-group">
-                <%= form.submit "Save Time Zone", class: "btn btn-primary" %>
-              </div>
-            <% end %>
-          </div>
-        <% end %>
+          <% if current_page?(root_path) == false %>
+            <%= link_to "Back to Dashboard", root_path, class: "btn btn-primary mb-2" %>
+          <% end %>
+        </div>
+        <div id="timezone-display">
+          <% if current_user.time_zone.present? %>
+            <p>Current Time Zone: <%= current_user.time_zone %></p>
+          <% else %>
+            <!-- Time Zone Selection Form -->
+            <div id="timezone-selection">
+              <p>We couldn't detect your time zone. Please select it manually:</p>
+              <%= form_with(url: "/set_time_zone", method: :post, local: true) do |form| %>
+                <div class="form-group">
+                  <%= form.label :time_zone, "Select Your Time Zone" %>
+                  <%= form.time_zone_select :time_zone, ActiveSupport::TimeZone.all, {}, class: "form-control" %>
+                </div>
+                <div class="form-group">
+                  <%= form.submit "Save Time Zone", class: "btn btn-primary" %>
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
       </div>
     <% end %>
 

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -5,6 +5,3 @@ pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "bootstrap", to: "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
 pin "@popperjs/core", to: "https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js"
-
-
-

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -10,12 +10,10 @@ Rails.application.configure do
     policy.font_src :self, :https, :data
     policy.img_src :self, :https, :data
     policy.object_src :none
-    policy.script_src :self, :https, :unsafe_inline, :unsafe_eval
-    # Allow inline styles and styles from jsdelivr.net (Bootstrap CDN)
-    policy.style_src :self, :https, :unsafe_inline, "https://cdn.jsdelivr.net"
+    policy.script_src :self, :https, :unsafe_eval
+    policy.style_src :self, :https, :unsafe_inline
   end
 
-  # Enable nonce generation
   config.content_security_policy_nonce_generator = ->(request) { SecureRandom.base64(16) }
   config.content_security_policy_nonce_directives = %w(script-src style-src)
 end


### PR DESCRIPTION
Fixes route for previous challenges, adds dropdown functionality on previous challenge show page, updates calculation for total time in model and challenges controller, makes logout button orange, adds back to dashboard button when on pages that are not dashboard while logged in. Can make. more improvements, everything still works on dashboard page like before. Will have to see on mobile if works like on desktop. 